### PR TITLE
Refactor to remove duplication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	python3 -m unittest discover --start-directory smart_importer --pattern "*_test.py"
+	tox -e py3
 
 .PHONY: lint
 lint:

--- a/smart_importer/decorator_baseclass.py
+++ b/smart_importer/decorator_baseclass.py
@@ -1,41 +1,44 @@
 import inspect
 import logging
-from abc import ABCMeta, abstractmethod
 from functools import wraps
 from typing import List, Union
 
-from beancount.core.data import Transaction, ALL_DIRECTIVES
+from beancount.core.data import Transaction, ALL_DIRECTIVES, filter_txns
+
+from smart_importer.machinelearning_helpers import load_training_data
+from smart_importer.machinelearning_helpers import merge_non_transaction_entries
 
 logger = logging.getLogger(__name__)
 
 
-class SmartImporterDecorator(metaclass=ABCMeta):
-    '''
-    Abstract base class for beancount importer class or method decorators.
+class ImporterDecorator():
+    """Abstract base class for Beancount importer class or method decorators.
 
     Instance Variables:
 
     * `existing_entries`: List[Transaction]
-      Existing entries are obtained from the `existing_entries` argument that may be provided to a beancount importer's
-      extract method. These entries are pre-existing data, typically transactions from a beancount file prior to
-      starting the import.
+      Existing entries are obtained from the `existing_entries` argument that
+      may be provided to a beancount importer's extract method. These entries
+      are pre-existing data, typically transactions from a beancount file prior
+      to starting the import.
 
     * `imported_entries`: List[Transaction]
       Imported entries result from calling the importer's extract method.
-      These entries are the data to be imported.
-      Decorators that inherit from SmartImporterDecorator will typically modify or enhance these entries in some way.
+      These entries are the data to be imported.  Decorators that inherit from
+      SmartImporterDecorator will typically modify or enhance these entries in
+      some way.
 
     * `account`: str
       The target account for the entries to be imported.
       It is obtained by calling the importer's file_account method.
-    '''
+    """
 
-    @abstractmethod
-    def __init__(self, *, training_data: List[Transaction] = None):
-        '''
-        Decorators that inherit from this class shall overwrite and implement this method, with parameters they need,
-        for example a parameter for training data to be used for machine learning.
-        '''
+    def __init__(self, training_data: List[Transaction]):
+        """
+        Decorators that inherit from this class shall overwrite and implement
+        this method, with parameters they need, for example a parameter for
+        training data to be used for machine learning.
+        """
         self.training_data = training_data
 
     # Implementation notes for how to write decorators for classes, see e.g.,
@@ -43,35 +46,33 @@ class SmartImporterDecorator(metaclass=ABCMeta):
     # https://www.codementor.io/sheena/advanced-use-python-decorators-class-function-du107nxsv
     # https://andrefsp.wordpress.com/2012/08/23/writing-a-class-decorator-in-python/
 
-    def __call__(self, to_be_decorated=None, *args, **kwargs):
-        '''
-        This method is called when the decorator is applied.
-        It may be applied to a beancount importer class or to its extract method,
-        the resulting behavior shall be the same.
-        '''
+    def __call__(self, to_be_decorated):
+        """
+        This method is called when the decorator is applied. It may be applied
+        to a Beancount importer class or to its extract method.
+        """
         if inspect.isclass(to_be_decorated):
             logger.debug('The Decorator was applied to a class.')
             return self.patched_importer_class(to_be_decorated)
-
         elif inspect.isfunction(to_be_decorated):
             logger.debug('The Decorator was applied to an instancemethod.')
             return self.patched_extract_method(to_be_decorated)
 
     def patched_importer_class(self, importer_class):
-        '''
+        """
         Patches a beancount importer class by modifying its extract method.
         :param importer_class: The original importer class
         :return: The modified importer class with a patched extract method.
-        '''
+        """
         importer_class.extract = self.patched_extract_method(importer_class.extract)
         return importer_class
 
     def patched_extract_method(self, original_extract_method):
-        '''
+        """
         Patches a beancount importer's extract method by wrapping it.
         :param original_extract_method: The importer's original extract method
         :return: A patched extract method, created by wrapping the original extract method.
-        '''
+        """
         decorator = self
 
         @wraps(original_extract_method)
@@ -81,7 +82,7 @@ class SmartImporterDecorator(metaclass=ABCMeta):
             decorator.existing_entries = existing_entries
 
             # read the importer's `extract`ed entries
-            logger.debug(f"About to call the importer's extract method to receive entries to be imported...")
+            logger.debug("About to call the importer's extract method to receive entries to be imported...")
             if 'existing_entries' in inspect.signature(original_extract_method).parameters:
                 decorator.imported_entries = original_extract_method(self, file, existing_entries)
             else:
@@ -103,12 +104,61 @@ class SmartImporterDecorator(metaclass=ABCMeta):
 
         return wrapper
 
-    @abstractmethod
     def main(self) -> List[Union[ALL_DIRECTIVES]]:
-        '''
+        """
         The decorator's main method, to be implemented by inheriting classes with the following functionality:
         1. read `self.imported_entries`
         2. process these entries
         3. return possibly modified entries
-        '''
+        """
         pass
+
+
+class SmartImporterDecorator(ImporterDecorator):
+    def main(self):
+        """
+        The decorator's main method predicts and suggests the account names
+        for imported transactions.
+        """
+        try:
+            self.load_training_data()
+            self.prepare_training_data()
+            self.define_pipeline()
+            self.train_pipeline()
+            return self.process_entries()
+        except (ValueError, AssertionError) as exception:
+            logger.error(exception)
+            return self.imported_entries
+
+    def load_training_data(self):
+        """Loads training data, i.e., a list of Beancount entries."""
+        self.training_data = load_training_data(
+            self.training_data,
+            known_account=self.account,
+            existing_entries=self.existing_entries)
+
+    def prepare_training_data(self):
+        pass
+
+    def define_pipeline(self):
+        raise NotImplementedError
+
+    def train_pipeline(self):
+        raise NotImplementedError
+
+    def process_entries(self) -> List[Union[ALL_DIRECTIVES]]:
+        """
+        Processes all imported entries (transactions as well as other types of
+        entries).  Transactions are enhanced, but all other entries are left as
+        is.
+        :return: Returns the list of entries to be imported.
+        """
+        imported_transactions: List[Transaction]
+        imported_transactions = list(filter_txns(self.imported_entries))
+        enhanced_transactions = self.process_transactions(
+            list(imported_transactions))
+        return merge_non_transaction_entries(self.imported_entries,
+                                             enhanced_transactions)
+
+    def process_transactions(self, transactions):
+        raise NotImplementedError

--- a/smart_importer/predict_payees.py
+++ b/smart_importer/predict_payees.py
@@ -6,7 +6,7 @@ using machine learning.
 import logging
 from typing import List, Union
 
-from beancount.core.data import Transaction, filter_txns, ALL_DIRECTIVES
+from beancount.core.data import Transaction
 from beancount.ingest.cache import _FileMemo
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.pipeline import Pipeline, FeatureUnion
@@ -44,42 +44,12 @@ class PredictPayees(SmartImporterDecorator):
                  predict_payees: bool = True,
                  overwrite_existing_payees=False,
                  suggest_payees: bool = False):
-        self.training_data = training_data
+        super().__init__(training_data)
         self.account = account
         self.predict_payees = predict_payees
         self.overwrite_existing_payees = overwrite_existing_payees
         self.suggest_payees = suggest_payees
-
-    def main(self):
-        '''
-        Predicts and suggests payees for imported transactions.
-        '''
-        try:
-            self.load_training_data()
-            self.prepare_training_data()
-            self.define_pipeline()
-            self.train_pipeline()
-            return self.process_entries()
-        except (ValueError, AssertionError) as e:
-            logger.error(e)
-            return self.imported_entries
-
-    def load_training_data(self):
-        '''
-        Loads training data, i.e., a list of beancount entries.
-        '''
-        self.training_data = ml.load_training_data(
-            self.training_data,
-            known_account=self.account,
-            existing_entries=self.existing_entries)
-
-    def prepare_training_data(self):
-        '''
-        Prepares the training data in preparation for training the machine learning pipeline.
-        In the case of this decorator, no steps are necessary here.
-        '''
-
-        pass
+        self.pipeline = None
 
     def define_pipeline(self):
         '''
@@ -123,17 +93,6 @@ class PredictPayees(SmartImporterDecorator):
         self.pipeline.fit(self.training_data, ml.GetPayee().transform(self.training_data))
         logger.info("Finished training the machine learning model.")
 
-    def process_entries(self) -> List[Union[ALL_DIRECTIVES]]:
-        '''
-        Processes all imported entries (transactions as well as other types of entries).
-        Transactions are enhanced, but all other entries are left as is.
-        :return: Returns the list of entries to be imported.
-        '''
-        imported_transactions: List[Transaction]
-        imported_transactions = list(filter_txns(self.imported_entries))
-        enhanced_transactions = self.process_transactions(list(imported_transactions))
-        return ml.merge_non_transaction_entries(self.imported_entries, enhanced_transactions)
-
     def process_transactions(self, transactions: List[Transaction]) -> List[Transaction]:
         '''
         Processes all imported transactions:
@@ -148,8 +107,10 @@ class PredictPayees(SmartImporterDecorator):
             logger.debug("About to generate predictions for payees...")
             predicted_payees: List[str]
             predicted_payees = self.pipeline.predict(transactions)
-            transactions = [ml.add_payee_to_transaction(*t_p, overwrite=self.overwrite_existing_payees)
-                            for t_p in zip(transactions, predicted_payees)]
+            transactions = [
+                ml.add_payee_to_transaction(
+                    *t_p, overwrite=self.overwrite_existing_payees)
+                for t_p in zip(transactions, predicted_payees)]
             logger.debug("Finished adding predicted payees to the transactions to be imported.")
 
         # suggest likely payees
@@ -158,13 +119,20 @@ class PredictPayees(SmartImporterDecorator):
             logger.debug("About to generate suggestions about likely payees...")
             decision_values = self.pipeline.decision_function(transactions)
 
-            # add a human-readable class label (i.e., payee's name) to each value, and sort by value:
-            suggested_payees = [[payee for _, payee in sorted(list(zip(distance_values, self.pipeline.classes_)),
-                                                              key=lambda x: x[0], reverse=True)]
-                                for distance_values in decision_values]
+            # add a human-readable class label (i.e., payee's name) to each
+            # value, and sort by value:
+            suggested_payees = [
+                [payee for _, payee in sorted(list(zip(distance_values,
+                                                       self.pipeline.classes_)),
+                                              key=lambda x: x[0], reverse=True)]
+                for distance_values in decision_values
+            ]
 
             # add the suggested payees to each transaction:
-            transactions = [ml.add_suggested_payees_to_transaction(*t_p)
-                            for t_p in zip(transactions, suggested_payees)]
-            logger.debug("Finished adding suggested payees to the transactions to be imported.")
+            transactions = [
+                ml.add_suggested_payees_to_transaction(*t_p)
+                for t_p in zip(transactions, suggested_payees)
+            ]
+            logger.debug("Finished adding suggested payees to the transactions "
+                         "to be imported.")
         return transactions

--- a/tests/machinelearning_helpers_test.py
+++ b/tests/machinelearning_helpers_test.py
@@ -88,7 +88,7 @@ class MachinelearningTest(unittest.TestCase):
         self.assertEqual(ml.GetPayee().transform(self.test_data),
                          ['Farmer Fresh', 'Starbucks', 'Farmer Fresh', 'Gimme Coffee'])
 
-    def test_get_payee(self):
+    def test_get_payee2(self):
         logger.info("Running Test Case: {id}".format(id=self.id().split('.')[-1]))
         self.assertEqual(ml.GetNarration().transform(self.test_data),
                          ['Buying groceries', 'Coffee', 'Groceries', 'Coffee'])

--- a/tests/predict_payees_test.py
+++ b/tests/predict_payees_test.py
@@ -227,7 +227,8 @@ class PredictPostingsDecorationTest(unittest.TestCase):
         logger.info("Running Test Case: {id}".format(id=self.id().split('.')[-1]))
 
         @PredictPayees()
-        class SmartTestImporter(BasicTestImporter): pass
+        class SmartTestImporter(BasicTestImporter):
+            pass
 
         i = SmartTestImporter()
         self.assertIsInstance(i, SmartTestImporter,

--- a/tests/predict_postings_data_test.py
+++ b/tests/predict_postings_data_test.py
@@ -42,7 +42,7 @@ class PredictPostingsTest(unittest.TestCase):
         @PredictPostings(suggest_accounts=True)
         class DummyImporter(ImporterProtocol):
             def extract(self, file: _FileMemo, existing_entries: List[Union[ALL_DIRECTIVES]]) -> List[
-                Union[ALL_DIRECTIVES]]:
+                    Union[ALL_DIRECTIVES]]:
                 return extracted_data
 
         importer = DummyImporter()

--- a/tests/predict_postings_test.py
+++ b/tests/predict_postings_test.py
@@ -12,6 +12,7 @@ from smart_importer.predict_postings import PredictPostings
 
 logger = logging.getLogger(__name__)
 
+
 class Testdata:
     test_data: List[Transaction]
     test_data, errors, _ = parser.parse_string("""
@@ -212,7 +213,8 @@ class PredictPostingsDecorationTest(unittest.TestCase):
         logger.info("Running Test Case: {id}".format(id=self.id().split('.')[-1]))
 
         @PredictPostings()
-        class SmartTestImporter(BasicTestImporter): pass
+        class SmartTestImporter(BasicTestImporter):
+            pass
 
         i = SmartTestImporter()
         self.assertIsInstance(i, SmartTestImporter,

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,5 @@ deps =
     pylint
     pytest
 commands =
-    flake8 --ignore E501 smart_importer
-    pylint smart_importer
+    flake8 --ignore E501 smart_importer tests
+    pylint smart_importer tests


### PR DESCRIPTION
Close #47 

I haven't worked much with abstract base classes before and SmartImporterDecorator is not really abstract at all, so I'm planning to remove that abc stuff...

I think it' better to have two base classes: ImporterDecorator which handles the decorator-related tasks and then secondly SmartImporterDecorator which implements the shared methods of PredictPostings and PredictPayees