### PR TITLE
Apply to most recent version of the CSV importer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,10 +54,9 @@ an existing CSV importer:
                  Col.AMOUNT_CREDIT: 'Funds In'},
                 account,
                 'EUR',
-                [
-                    'Filename: .*MyBank.*\.csv',
-                    'Contents:\n.*Date, Transaction Details, Funds Out, Funds In'
-                ]
+                (
+                    'Date, Transaction Details, Funds Out, Funds In'
+                )
             )
 
 


### PR DESCRIPTION
The latest version of the CSV importer beancount/ingest/importers/csv does not support the format of **kwds in the readme here.