### PR TITLE
fixes sklearn error when a valid but empty bank statement is passed

### DIFF
--- a/smart_importer/predictor.py
+++ b/smart_importer/predictor.py
@@ -184,12 +184,16 @@ class EntryPredictor(ImporterHook):
             return transactions
 
         if self.predict:
-            predictions = self.pipeline.predict(transactions)
-            transactions = [
-                self.apply_prediction(entry, prediction)
-                for entry, prediction in zip(transactions, predictions)
-            ]
-            logger.debug("Added predictions to transactions.")
+            if len(transactions) > 0: # if zero, sklearn throws error
+                predictions = self.pipeline.predict(transactions)
+                transactions = [
+                    self.apply_prediction(entry, prediction)
+                    for entry, prediction in zip(transactions, predictions)
+                ]
+                logger.debug("Added predictions to transactions.")
+            else:
+                transactions=[]
+                print('**** no transactions in file')
 
         if self.suggest:
             # Get values from the SVC decision function


### PR DESCRIPTION
when passing an empty but valid bank statement with smart importer, sklearn throws an error (see below). a simple if clause catching that case helps.

(Bean) path@machine:~/myfiles/path$ bean-extract Config.py ../download/ -f main.bean > importdump.bean
ERROR:root:Importer DKB CreditImporter.extract() raised an unexpected error: Found array with 0 sample(s) (shape=(0, 609)) while a minimum of 1 is required.
ERROR:root:Traceback: Traceback (most recent call last):
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/beancount/ingest/extract.py", line 193, in extract
    allow_none_for_tags_and_links=allow_none_for_tags_and_links)
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/beancount/ingest/extract.py", line 69, in extract_from_file
    new_entries = importer.extract(file, **kwargs)
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/smart_importer/hooks.py", line 46, in patched_extract_method
    importer, file, imported_entries, existing_entries
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/smart_importer/predictor.py", line 65, in __call__
    return self.process_entries(imported_entries)
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/smart_importer/predictor.py", line 145, in process_entries
    list(filter_txns(imported_entries))
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/smart_importer/predictor.py", line 185, in process_transactions
    predictions = self.pipeline.predict(transactions)
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/sklearn/utils/metaestimators.py", line 116, in <lambda>
    out = lambda *args, **kwargs: self.fn(obj, *args, **kwargs)
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/sklearn/pipeline.py", line 420, in predict
    return self.steps[-1][-1].predict(Xt, **predict_params)
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/sklearn/svm/_base.py", line 594, in predict
    y = super().predict(X)
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/sklearn/svm/_base.py", line 315, in predict
    X = self._validate_for_predict(X)
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/sklearn/svm/_base.py", line 447, in _validate_for_predict
    accept_large_sparse=False)
  File "/home/path/miniconda3/envs/Bean/lib/python3.7/site-packages/sklearn/utils/validation.py", line 586, in check_array
    context))
ValueError: Found array with 0 sample(s) (shape=(0, 609)) while a minimum of 1 is required.