### PR TITLE
Filter transactions to only those referencing open accounts

### DIFF
--- a/tests/data/multiaccounts.beancount
+++ b/tests/data/multiaccounts.beancount
@@ -3,6 +3,12 @@
   Assets:US:EUR  -2.50 USD
 
 # TRAINING
+2016-01-01 open Assets:US:CHF USD
+2016-01-01 open Assets:US:EUR USD
+2016-01-01 open Assets:US:USD USD
+2016-01-01 open Expenses:Food:Swiss USD
+2016-01-01 open Expenses:Food:Europe USD
+2016-01-01 open Expenses:Food:Usa USD
 2016-01-06 * "Foo"
   Assets:US:CHF  -2.50 USD
   Expenses:Food:Swiss

--- a/tests/data/simple.beancount
+++ b/tests/data/simple.beancount
@@ -20,6 +20,11 @@
     Assets:US:BofA:Checking  -5.00 USD
 
 # TRAINING
+2016-01-01 open Assets:US:BofA:Checking USD
+2016-01-01 open Expenses:Food:Coffee USD
+2016-01-01 open Expenses:Food:Groceries USD
+2016-01-01 open Expenses:Food:Restaurant USD
+
 2016-01-06 * "Farmer Fresh" "Buying groceries"
     Assets:US:BofA:Checking  -2.50 USD
     Expenses:Food:Groceries

--- a/tests/data/single-account.beancount
+++ b/tests/data/single-account.beancount
@@ -3,6 +3,9 @@
     Assets:US:BofA:Checking  -2.50 USD
 
 # TRAINING
+2016-01-01 open Assets:US:BofA:Checking USD
+2016-01-01 open Expenses:Food:Groceries USD
+
 2016-01-06 * "Farmer Fresh" "Buying groceries"
     Assets:US:BofA:Checking  -2.50 USD
     Expenses:Food:Groceries

--- a/tests/pipelines_test.py
+++ b/tests/pipelines_test.py
@@ -6,6 +6,10 @@ from smart_importer.pipelines import AttrGetter
 
 TEST_DATA, _, __ = parser.parse_string(
     """
+2016-01-01 open Assets:US:BofA:Checking USD
+2016-01-01 open Expenses:Food:Groceries USD
+2016-01-01 open Expenses:Food:Coffee USD
+
 2016-01-06 * "Farmer Fresh" "Buying groceries"
   Assets:US:BofA:Checking  -10.00 USD
 
@@ -22,11 +26,12 @@ TEST_DATA, _, __ = parser.parse_string(
   Expenses:Food:Coffee
 """
 )
-TEST_TRANSACTION = TEST_DATA[0]
+TEST_TRANSACTIONS = TEST_DATA[3:]
+TEST_TRANSACTION = TEST_TRANSACTIONS[0]
 
 
 def test_get_payee():
-    assert AttrGetter("payee").transform(TEST_DATA) == [
+    assert AttrGetter("payee").transform(TEST_TRANSACTIONS) == [
         "Farmer Fresh",
         "Starbucks",
         "Farmer Fresh",
@@ -35,7 +40,7 @@ def test_get_payee():
 
 
 def test_get_narration():
-    assert AttrGetter("narration").transform(TEST_DATA) == [
+    assert AttrGetter("narration").transform(TEST_TRANSACTIONS) == [
         "Buying groceries",
         "Coffee",
         "Groceries",
@@ -44,10 +49,10 @@ def test_get_narration():
 
 
 def test_get_metadata():
-    txn = TEST_DATA[0]
+    txn = TEST_TRANSACTION
     txn.meta["attr"] = "value"
     assert AttrGetter("meta.attr").transform([txn]) == ["value"]
-    assert AttrGetter("meta.attr", "default").transform(TEST_DATA) == [
+    assert AttrGetter("meta.attr", "default").transform(TEST_TRANSACTIONS) == [
         "value",
         "default",
         "default",
@@ -56,4 +61,4 @@ def test_get_metadata():
 
 
 def test_get_day_of_month():
-    assert AttrGetter("date.day").transform(TEST_DATA) == [6, 7, 7, 8]
+    assert AttrGetter("date.day").transform(TEST_TRANSACTIONS) == [6, 7, 7, 8]

--- a/tests/predictors_test.py
+++ b/tests/predictors_test.py
@@ -29,11 +29,21 @@ TEST_DATA, _, __ = parser.parse_string(
 
 2017-01-12 * "Uncle Boons" ""
   Assets:US:BofA:Checking  -27.00 USD
+
+2017-01-13 * "Gas Quick"
+  Assets:US:BofA:Checking  -17.45 USD
 """
 )
 
 TRAINING_DATA, _, __ = parser.parse_string(
     """
+2016-01-01 open Assets:US:BofA:Checking USD
+2016-01-01 open Expenses:Food:Coffee USD
+2016-01-01 open Expenses:Auto:Diesel USD
+2016-01-01 open Expenses:Auto:Gas USD
+2016-01-01 open Expenses:Food:Groceries USD
+2016-01-01 open Expenses:Food:Restaurant USD
+
 2016-01-06 * "Farmer Fresh" "Buying groceries"
   Assets:US:BofA:Checking  -2.50 USD
   Expenses:Food:Groceries
@@ -50,6 +60,10 @@ TRAINING_DATA, _, __ = parser.parse_string(
   Assets:US:BofA:Checking  -3.50 USD
   Expenses:Food:Coffee
 
+2016-01-07 * "Gas Quick"
+  Assets:US:BofA:Checking  -22.79 USD
+  Expenses:Auto:Diesel
+
 2016-01-08 * "Uncle Boons" "Eating out with Joe"
   Assets:US:BofA:Checking  -38.36 USD
   Expenses:Food:Restaurant
@@ -62,13 +76,23 @@ TRAINING_DATA, _, __ = parser.parse_string(
   Assets:US:BofA:Checking  -6.19 USD
   Expenses:Food:Coffee
 
+2016-01-10 * "Gas Quick"
+  Assets:US:BofA:Checking  -21.60 USD
+  Expenses:Auto:Diesel
+
 2016-01-10 * "Uncle Boons" "Dinner with Mary"
   Assets:US:BofA:Checking  -35.00 USD
   Expenses:Food:Restaurant
 
+2016-01-11 close Expenses:Auto:Diesel
+
 2016-01-11 * "Farmer Fresh" "Groceries"
   Assets:US:BofA:Checking  -30.50 USD
   Expenses:Food:Groceries
+
+2016-01-12 * "Gas Quick"
+  Assets:US:BofA:Checking  -24.09 USD
+  Expenses:Auto:Gas
 """
 )
 
@@ -80,6 +104,7 @@ PAYEE_PREDICTIONS = [
     "Farmer Fresh",
     "Gimme Coffee",
     "Uncle Boons",
+    None,
 ]
 
 ACCOUNT_PREDICTIONS = [
@@ -90,6 +115,7 @@ ACCOUNT_PREDICTIONS = [
     "Expenses:Food:Groceries",
     "Expenses:Food:Coffee",
     "Expenses:Food:Groceries",
+    "Expenses:Auto:Gas",
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     flake8
     pylint
     pytest
-    hg+https://bitbucket.org/blais/beancount#egg=beancount
+    git+https://github.com/beancount/beancount#v2=beancount
 commands =
     black --check smart_importer tests
     flake8 smart_importer tests


### PR DESCRIPTION
This is a quick attempt at addressing https://github.com/beancount/smart_importer/issues/26 by only using transactions with all their postings to/from open accounts as training data.