### PR TITLE
Fixes github ci build: Uses matrix build for testing only, not for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: ci
 on:
   push:
-  release:
-    types: [published]
 jobs:
-  build-and-publish:
+  test:
     name: Run tests and build distribution
     runs-on: ubuntu-latest
     strategy:
@@ -26,11 +24,25 @@ jobs:
     - name: Run tests
       run: >-
         tox -e py
+  build-and-publish:
+    name: Build and publish a distribution
+    runs-on: ubuntu-latest
+    needs: test  # the test job must have been successful
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install Dependencies
+      run: |
+        pip install wheel setuptools
     - name: Build distribution
       run: >-
         make dist
-    - name: Publish distribution 📦 to PyPI (on tags)
-      if: startsWith(github.event.ref, 'refs/tags')
+    - name: Publish distribution 📦 to PyPI (on tags starting with v)
+      if: startsWith(github.event.ref, 'refs/tags/v')
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run: >-
         tox -e py
   build-and-publish:
-    name: Build and publish a distribution
+    name: Build and optionally publish a distribution
     runs-on: ubuntu-latest
     needs: test  # the test job must have been successful
     steps:
@@ -41,7 +41,7 @@ jobs:
     - name: Build distribution
       run: >-
         make dist
-    - name: Publish distribution 📦 to PyPI (on tags starting with v)
+    - name: Publish distribution package to PyPI (on tags starting with v)
       if: startsWith(github.event.ref, 'refs/tags/v')
       env:
         TWINE_USERNAME: __token__


### PR DESCRIPTION
When I introduced github-ci matrix builds in the github ci workflow, I accidentally also activated the matrix build for how the package is published to pypi. This is a bug - obviously, we don't want a matrix of different python versions race against each other, each trying to upload the same package to pypi.

This pull request introduces two separate ci jobs. One for testing (this job uses a matrix of different python versions), one for publishing (without using a matrix). 