### PR TITLE
[Feature] Add Chinese support via Jieba tokenizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # intellij project files
 .idea/
 
+# vscode project files
+.vscode/
+
 # python caches
 __pycache__/
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     scikit-learn>=0.19
     numpy>=1.8.2
     scipy>=0.13.3
+    jieba>=0.42
 
 [options.packages.find]
 exclude =

--- a/tests/predictors_test.py
+++ b/tests/predictors_test.py
@@ -117,11 +117,118 @@ ACCOUNT_PREDICTIONS = [
     "Expenses:Auto:Gas",
 ]
 
+CHINESE_TEST_DATA, _, __ = parser.parse_string(
+    """
+2017-01-06 * "菜市场" "买杂货"
+  Assets:US:BofA:Checking  -2.50 USD
+
+2017-01-07 * "杂货"
+  Assets:US:BofA:Checking  -10.20 USD
+
+2017-01-10 * "" "和老李吃饭"
+  Assets:US:BofA:Checking  -38.36 USD
+
+2017-01-10 * "和马丁吃饭"
+  Assets:US:BofA:Checking  -35.00 USD
+
+2017-01-10 * "杂货"
+  Assets:US:BofA:Checking  -53.70 USD
+
+2017-01-10 * "Gimme 咖啡" "咖啡"
+  Assets:US:BofA:Checking  -5.00 USD
+
+2017-01-12 * "和府酒楼" ""
+  Assets:US:BofA:Checking  -27.00 USD
+
+2017-01-13 * "中国石化"
+  Assets:US:BofA:Checking  -17.45 USD
+"""
+)
+
+
+CHINESE_TRAINING_DATA, _, __ = parser.parse_string(
+    """
+2016-01-01 open Assets:US:BofA:Checking USD
+2016-01-01 open Expenses:Food:Coffee USD
+2016-01-01 open Expenses:Auto:Diesel USD
+2016-01-01 open Expenses:Auto:Gas USD
+2016-01-01 open Expenses:Food:Groceries USD
+2016-01-01 open Expenses:Food:Restaurant USD
+
+2016-01-06 * "菜市场" "买杂货"
+  Assets:US:BofA:Checking  -2.50 USD
+  Expenses:Food:Groceries
+
+2016-01-07 * "星巴克" "咖啡"
+  Assets:US:BofA:Checking  -4.00 USD
+  Expenses:Food:Coffee
+
+2016-01-07 * "菜市场" "杂货"
+  Assets:US:BofA:Checking  -10.20 USD
+  Expenses:Food:Groceries
+
+2016-01-07 * "Gimme 咖啡" "咖啡"
+  Assets:US:BofA:Checking  -3.50 USD
+  Expenses:Food:Coffee
+
+2016-01-07 * "中国石化"
+  Assets:US:BofA:Checking  -22.79 USD
+  Expenses:Auto:Diesel
+
+2016-01-08 * "和府酒楼" "和老李吃饭"
+  Assets:US:BofA:Checking  -38.36 USD
+  Expenses:Food:Restaurant
+
+2016-01-10 * "沃尔玛" "杂货"
+  Assets:US:BofA:Checking  -53.70 USD
+  Expenses:Food:Groceries
+
+2016-01-10 * "Gimme 咖啡" "咖啡"
+  Assets:US:BofA:Checking  -6.19 USD
+  Expenses:Food:Coffee
+
+2016-01-10 * "中国石化"
+  Assets:US:BofA:Checking  -21.60 USD
+  Expenses:Auto:Diesel
+
+2016-01-10 * "和府酒楼" "和小王吃饭"
+  Assets:US:BofA:Checking  -35.00 USD
+  Expenses:Food:Restaurant
+
+2016-01-10 * "和府酒楼" "和小王吃饭"
+  Assets:US:BofA:Checking  -35.00 USD
+  Expenses:Food:Restaurant
+
+2016-01-11 close Expenses:Auto:Diesel
+
+2016-01-11 * "菜市场" "杂货"
+  Assets:US:BofA:Checking  -30.50 USD
+  Expenses:Food:Groceries
+
+2016-01-12 * "中国石化"
+  Assets:US:BofA:Checking  -24.09 USD
+  Expenses:Auto:Gas
+"""
+)
+
+CHINESE_PAYEE_PREDICTIONS = [
+    "菜市场",
+    "菜市场",
+    "和 府 酒楼",
+    "和 府 酒楼",
+    "菜市场",
+    "Gimme   咖啡",  # more spaces is made by jieba tokenizer
+    "和 府 酒楼",
+    None,
+]
+
 
 class BasicTestImporter(ImporterProtocol):
     def extract(self, file, existing_entries=None):
         if file == "dummy-data":
             return TEST_DATA
+        if file == "chinese-dummy-data":
+            return CHINESE_TEST_DATA
         if file == "empty":
             return []
         assert False
@@ -133,6 +240,13 @@ class BasicTestImporter(ImporterProtocol):
 
 PAYEE_IMPORTER = apply_hooks(BasicTestImporter(), [PredictPayees()])
 POSTING_IMPORTER = apply_hooks(BasicTestImporter(), [PredictPostings()])
+
+CHINESE_PAYEE_IMPORTER = apply_hooks(
+    BasicTestImporter(), [PredictPayees(chinese_participle_support=True)]
+)
+CHINESE_POSTING_IMPORTER = apply_hooks(
+    BasicTestImporter(), [PredictPostings(chinese_participle_support=True)]
+)
 
 
 def test_empty_training_data():
@@ -204,4 +318,30 @@ def test_account_predictions():
             "dummy-data", existing_entries=TRAINING_DATA
         )
     ]
+    assert predicted_accounts == ACCOUNT_PREDICTIONS
+
+
+def test_chinese_payee_predictions():
+    """
+    Verifies that the decorator adds predicted postings.
+    """
+    transactions = CHINESE_PAYEE_IMPORTER.extract(
+        "chinese-dummy-data", existing_entries=CHINESE_TRAINING_DATA
+    )
+    predicted_payees = [transaction.payee for transaction in transactions]
+    assert predicted_payees == CHINESE_PAYEE_PREDICTIONS
+
+
+def test_chinese_account_predictions():
+    """
+    Verifies that the decorator adds predicted postings.
+    """
+    predicted_accounts = [
+        entry.postings[-1].account
+        for entry in CHINESE_POSTING_IMPORTER.extract(
+            "chinese-dummy-data", existing_entries=CHINESE_TRAINING_DATA
+        )
+    ]
+    print(predicted_accounts)
+    print(ACCOUNT_PREDICTIONS)
     assert predicted_accounts == ACCOUNT_PREDICTIONS


### PR DESCRIPTION
Hi Contributors,

I am Chinese, and love Beancount, also want to use smart_import to enhance experiences when I import Bank statements. I try this tool, but you know, the Chinese did not have a break or space within words. So the SVM cannot analyze Chinese now. Here is a Chinese sentence.

eg. "我和小明一起吃晚饭。"

We rely on the tokenizer tool to split words. So I used the most popular tokenizer tool [jieba](https://github.com/fxsjy/jieba) to support this function.

I am sure, my code can let the smart_import smarter. I wrote some code and tests but in a rude way.

If you have any suggestions or feedback, very welcome to write them here.

Thanks.