### PR TITLE
Sort posting accounts in PredictPostings.target

### DIFF
--- a/smart_importer/__init__.py
+++ b/smart_importer/__init__.py
@@ -19,7 +19,7 @@ class PredictPostings(EntryPredictor):
     @property
     def targets(self):
         return [
-            " ".join(posting.account for posting in txn.postings)
+            " ".join(sorted(posting.account for posting in txn.postings))
             for txn in self.training_data
         ]
 


### PR DESCRIPTION
The order shouldn't matter so this will improve prediction quality in cases where accounts are present in different orders.