### PR TITLE
feat(predictor): Add support for denylisting accounts

### DIFF
--- a/smart_importer/predictor.py
+++ b/smart_importer/predictor.py
@@ -54,12 +54,12 @@ class EntryPredictor(ImporterHook):
         predict=True,
         overwrite=False,
         string_tokenizer: Callable[[str], list] | None = None,
-        denylist_accounts: list[str] = []
+        denylist_accounts: list[str] | None = None,
     ):
         super().__init__()
         self.training_data = None
         self.open_accounts: dict[str, str] = {}
-        self.denylist_accounts = denylist_accounts
+        self.denylist_accounts = denylist_accounts or []
         self.pipeline: Pipeline | None = None
         self.is_fitted = False
         self.lock = threading.Lock()

--- a/smart_importer/predictor.py
+++ b/smart_importer/predictor.py
@@ -42,6 +42,8 @@ class EntryPredictor(ImporterHook):
         string_tokenizer: Tokenizer can let smart_importer support more
             languages. This parameter should be an callable function with
             string parameter and the returning should be a list.
+        denylist_accounts: Transations with any of these accounts will be
+            removed from the training data.
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -59,7 +61,7 @@ class EntryPredictor(ImporterHook):
         super().__init__()
         self.training_data = None
         self.open_accounts: dict[str, str] = {}
-        self.denylist_accounts = denylist_accounts or []
+        self.denylist_accounts = set(denylist_accounts or [])
         self.pipeline: Pipeline | None = None
         self.is_fitted = False
         self.lock = threading.Lock()

--- a/smart_importer/predictor.py
+++ b/smart_importer/predictor.py
@@ -54,10 +54,12 @@ class EntryPredictor(ImporterHook):
         predict=True,
         overwrite=False,
         string_tokenizer: Callable[[str], list] | None = None,
+        denylist_accounts: list[str] = []
     ):
         super().__init__()
         self.training_data = None
         self.open_accounts: dict[str, str] = {}
+        self.denylist_accounts = denylist_accounts
         self.pipeline: Pipeline | None = None
         self.is_fitted = False
         self.lock = threading.Lock()
@@ -132,6 +134,8 @@ class EntryPredictor(ImporterHook):
         found_import_account = False
         for pos in txn.postings:
             if pos.account not in self.open_accounts:
+                return False
+            if pos.account in self.denylist_accounts:
                 return False
             if self.account == pos.account:
                 found_import_account = True

--- a/tests/predictors_test.py
+++ b/tests/predictors_test.py
@@ -32,6 +32,9 @@ TEST_DATA, _, __ = parser.parse_string(
 
 2017-01-13 * "Gas Quick"
   Assets:US:BofA:Checking  -17.45 USD
+
+2017-01-14 * "Axe Throwing with Joe"
+  Assets:US:BofA:Checking  -13.37 USD
 """
 )
 
@@ -43,6 +46,7 @@ TRAINING_DATA, _, __ = parser.parse_string(
 2016-01-01 open Expenses:Auto:Gas USD
 2016-01-01 open Expenses:Food:Groceries USD
 2016-01-01 open Expenses:Food:Restaurant USD
+2016-01-01 open Expenses:Denylisted USD
 
 2016-01-06 * "Farmer Fresh" "Buying groceries"
   Assets:US:BofA:Checking  -2.50 USD
@@ -93,6 +97,11 @@ TRAINING_DATA, _, __ = parser.parse_string(
 2016-01-12 * "Gas Quick"
   Assets:US:BofA:Checking  -24.09 USD
   Expenses:Auto:Gas
+
+2016-01-08 * "Axe Throwing with Joe"
+  Assets:US:BofA:Checking  -38.36 USD
+  Expenses:Denylisted
+
 """
 )
 
@@ -105,6 +114,7 @@ PAYEE_PREDICTIONS = [
     "Gimme Coffee",
     "Uncle Boons",
     None,
+    None,
 ]
 
 ACCOUNT_PREDICTIONS = [
@@ -116,8 +126,10 @@ ACCOUNT_PREDICTIONS = [
     "Expenses:Food:Coffee",
     "Expenses:Food:Groceries",
     "Expenses:Auto:Gas",
+    "Expenses:Food:Groceries",
 ]
 
+DENYLISTED_ACCOUNTS = ["Expenses:Denylisted"]
 
 class BasicTestImporter(ImporterProtocol):
     def extract(self, file, existing_entries=None):
@@ -133,7 +145,7 @@ class BasicTestImporter(ImporterProtocol):
 
 
 PAYEE_IMPORTER = apply_hooks(BasicTestImporter(), [PredictPayees()])
-POSTING_IMPORTER = apply_hooks(BasicTestImporter(), [PredictPostings()])
+POSTING_IMPORTER = apply_hooks(BasicTestImporter(), [PredictPostings(denylist_accounts=DENYLISTED_ACCOUNTS)])
 
 
 def test_empty_training_data():

--- a/tests/predictors_test.py
+++ b/tests/predictors_test.py
@@ -131,6 +131,7 @@ ACCOUNT_PREDICTIONS = [
 
 DENYLISTED_ACCOUNTS = ["Expenses:Denylisted"]
 
+
 class BasicTestImporter(ImporterProtocol):
     def extract(self, file, existing_entries=None):
         if file == "dummy-data":
@@ -145,7 +146,10 @@ class BasicTestImporter(ImporterProtocol):
 
 
 PAYEE_IMPORTER = apply_hooks(BasicTestImporter(), [PredictPayees()])
-POSTING_IMPORTER = apply_hooks(BasicTestImporter(), [PredictPostings(denylist_accounts=DENYLISTED_ACCOUNTS)])
+POSTING_IMPORTER = apply_hooks(
+    BasicTestImporter(),
+    [PredictPostings(denylist_accounts=DENYLISTED_ACCOUNTS)],
+)
 
 
 def test_empty_training_data():


### PR DESCRIPTION
There are many occasions when the training data set may include accounts which should not be predicted (e.g., accounts used for manual reconciliation of AR/AP). This feature allows the user to stop the predictor from learning these accounts, thus preventing contamination of the training set, without having to maintain a separate filtered copy of their transactions.

NB: Currently, all CI runs are broken because of beancount 3.0 hitting PyPi. Manual testing with beancount<3.0.0 shows all tests passing.