### PR TITLE
pre-commit autoupdate; add to Makefile; use ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
-        pip install tox wheel setuptools
+        pip install tox wheel setuptools pre-commit
     - name: Run lint
+      run: >-
+        pre-commit run -a
+    - name: Run pylint
       run: >-
         tox -e lint
     - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,30 +17,14 @@ repos:
   - id: mixed-line-ending
     args: ['--fix=auto']
 
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.6.5
   hooks:
-  - id: isort
-
-- repo: https://github.com/psf/black
-  rev: 24.8.0
-  hooks:
-  - id: black
-    language_version: python3
-
-- repo: https://github.com/PyCQA/flake8
-  rev: 7.1.1
-  hooks:
-  - id: flake8
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args: ["--py37-plus"]
+    - id: ruff
+    - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.11.1
+  rev: v1.11.2
   hooks:
   -   id: mypy
       args: [--install-types, --non-interactive, --ignore-missing-imports]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 
 .PHONY: lint
 lint:
-	tox -e format
+	pre-commit run -a
 	tox -e lint
 
 .PHONY: install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 79
+
+[tool.ruff]
+target-version = "py38"
+line-length = 79
+
+[tool.ruff.lint]
+extend-select = [
+    "I",   # isort
+    "UP",  # pyupgrade
+]

--- a/tox.ini
+++ b/tox.ini
@@ -7,19 +7,10 @@ deps =
     jieba
 commands = pytest -v tests
 
-[testenv:format]
-skip_install = True
-deps = black
-commands = black .
-
 [testenv:lint]
 deps =
-    black
-    flake8
     pylint
     pytest
     jieba
 commands =
-    black --check smart_importer tests
-    flake8 smart_importer tests
     pylint smart_importer tests


### PR DESCRIPTION
ruff is really fast and has the rules of most of the linters we were
using so far.
