### PR TITLE
fix: skip classifier for known leg

### DIFF
--- a/smart_importer/__init__.py
+++ b/smart_importer/__init__.py
@@ -27,11 +27,20 @@ class PredictPostings(EntryPredictor):
     def targets(self) -> list[str]:
         assert self.training_data is not None
         return [
-            " ".join(sorted(posting.account for posting in txn.postings))
+            " ".join(
+                sorted(
+                    posting.account
+                    for posting in txn.postings
+                    if posting.account != self.account
+                )
+            )
             for txn in self.training_data
         ]
 
     def apply_prediction(
         self, entry: Transaction, prediction: str
     ) -> Transaction:
-        return update_postings(entry, prediction.split(" "))
+        accounts = prediction.split(" ")
+        if self.account:
+            accounts.insert(0, self.account)
+        return update_postings(entry, accounts)

--- a/smart_importer/predictor.py
+++ b/smart_importer/predictor.py
@@ -132,6 +132,7 @@ class EntryPredictor:
         self, all_transactions: list[Transaction], account: str
     ) -> None:
         """Load training data, i.e., a list of Beancount entries."""
+        self.account = account
         self.training_data = [
             txn
             for txn in all_transactions

--- a/tests/predictors_test.py
+++ b/tests/predictors_test.py
@@ -305,3 +305,32 @@ def test_account_predictions_multiple() -> None:
     ]
     assert predicted_accounts1 == ACCOUNT_PREDICTIONS
     assert predicted_accounts2 == ACCOUNT_PREDICTIONS
+
+
+def test_predict_postings_duplicate_accounts() -> None:
+    """Verifies that when providing the account, we only predict the unknown leg."""
+    training_data, _, _ = parser.parse_string(
+        """
+2016-01-01 open Assets:Bank:A USD
+2016-01-01 open Assets:Bank:B USD
+2016-01-01 open Expenses:Food USD
+
+2016-01-02 * "Starbucks"
+  Assets:Bank:A  -7.00 USD
+  Expenses:Food
+
+2016-01-02 * "Starbucks"
+  Assets:Bank:B  -7.00 USD
+  Expenses:Food
+"""
+    )
+    predictor = PredictPostings()
+
+    # 1. Failing case: account unknown (matches everything)
+    predictor.hook([("file", [], None, None)], training_data)
+    assert "Assets:Bank:A" in predictor.targets[0]
+    assert "Assets:Bank:B" in predictor.targets[1]
+
+    # 2. Passing case: account known (strips self.account)
+    predictor.hook([("file", [], "Assets:Bank:B", None)], training_data)
+    assert "Assets:Bank:B" not in predictor.targets[0]


### PR DESCRIPTION
This PR tentatively fixes #130.

Basically we skip the prediction stage for the importer account which we know with certainty already. 
We filter out the "import account" from the training targets, and add it back after the prediction stage:
- store import account in `EntryPredictor`
- `PredictPostings.targets` filters out import account from training data: no redundant bank account predictions
- In `apply_prediction`, the import account is prepended (index 0) to the predicted results

What do you think? 